### PR TITLE
Switch PostCSS plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "swr": "^2.3.3"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.10",
     "@types/node": "24.0.3",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.21",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- configure PostCSS to use the `tailwindcss` plugin
- drop unused `@tailwindcss/postcss` package

## Testing
- `npm install`
- `npm run build` *(fails: looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68501814ec008323b5bad5c899d362cf