### PR TITLE
Implement cached DB connect for API routes

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,8 +4,24 @@ const MONGODB_URI =
   process.env.MONGODB_URI ||
   'mongodb+srv://kaziwavijana:GvQCkSIcufEY1mgH@cluster0.1kkzax7.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
 
-if (!mongoose.connection.readyState) {
-  mongoose.connect(MONGODB_URI);
+// Use a global cached connection across hot reloads in development.
+let cached = (global as any).mongoose as
+  | { conn: typeof mongoose | null; promise: Promise<typeof mongoose> | null }
+  | undefined;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+export async function connect() {
+  if (cached!.conn) return cached!.conn;
+
+  if (!cached!.promise) {
+    cached!.promise = mongoose.connect(MONGODB_URI).then((m) => m);
+  }
+
+  cached!.conn = await cached!.promise;
+  return cached!.conn;
 }
 
 export default mongoose;

--- a/pages/api/orders/index.ts
+++ b/pages/api/orders/index.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Order } from '../../../lib/models';
+import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
   if (req.method === 'POST') {
     const order = await (Order as any).create(req.body);
     res.json(order);

--- a/pages/api/products/[id].ts
+++ b/pages/api/products/[id].ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Product } from '../../../lib/models';
+import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
   if (req.method === 'DELETE') {
     await (Product as any).findByIdAndDelete(req.query.id as string);
     res.json({});

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Product } from '../../../lib/models';
+import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
   if (req.method === 'GET') {
     const products = await (Product as any).find().lean();
     res.json(products);


### PR DESCRIPTION
## Summary
- implement a cached `connect()` helper for Mongoose
- ensure API routes establish the DB connection before using models

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853dd5707c08323901fbc3e2fedcfb7