### PR TITLE
Fix checkout form property

### DIFF
--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react';
-import { Product } from '../types';
+import { Product, Order } from '../types';
 
 export default function Checkout() {
-  const [form, setForm] = useState({ name: '', phone: '', address: '' });
+  const [form, setForm] = useState<Omit<Order, '_id' | 'createdAt'>>({
+    customerName: '',
+    phone: '',
+    address: '',
+    items: []
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -12,14 +17,14 @@ export default function Checkout() {
     await fetch('/api/orders', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, items: [] })
+      body: JSON.stringify(form)
     });
     alert('Order received! We will contact you shortly.');
   };
 
   return (
     <div className="p-4 space-y-2">
-      <input className="border p-1 w-full" name="name" placeholder="Name" onChange={handleChange} />
+      <input className="border p-1 w-full" name="customerName" placeholder="Name" onChange={handleChange} />
       <input className="border p-1 w-full" name="phone" placeholder="Phone" onChange={handleChange} />
       <input className="border p-1 w-full" name="address" placeholder="Address" onChange={handleChange} />
       <p>M-Pesa instructions will be sent to your phone.</p>


### PR DESCRIPTION
## Summary
- use `customerName` field in checkout form
- type the order form state to match the `Order` interface

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d5f4915888323a84aab0e15edea1e