### PR TITLE
Ensure footer remains at bottom

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,11 +6,13 @@ import Footer from '../components/Footer';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <Component {...pageProps} />
+      <main className="flex-grow">
+        <Component {...pageProps} />
+      </main>
       <Footer />
       <WhatsAppButton />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- make page layout fill the viewport using flexbox
- push footer to the bottom when content is short

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d91a18e908323bb86717adbb4b1ff