### PR TITLE
Add basic cart and product page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
+import { useCart } from '../lib/cart';
 
 export default function Header() {
+  const { items } = useCart();
   return (
     <header className="bg-blue-600 text-white p-4 flex justify-between items-center">
       <Link href="/" className="font-bold">Mtumba Online</Link>
       <nav className="space-x-4">
         <Link href="/">Home</Link>
-        <Link href="/checkout">Checkout</Link>
+        <Link href="/checkout">Cart ({items.length})</Link>
         <Link href="/admin">Admin</Link>
       </nav>
     </header>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,17 +1,25 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Product } from '../types';
+import { useCart } from '../lib/cart';
 
 interface Props {
   product: Product;
 }
 
 export default function ProductCard({ product }: Props) {
+  const { addItem } = useCart();
   return (
-    <div className="border rounded p-2">
-      <img src={product.imageUrl} alt={product.name} className="w-full h-40 object-cover" />
-      <h3 className="font-semibold mt-2">{product.name}</h3>
-      <p className="text-sm text-gray-500">{product.description}</p>
-      <p className="font-bold">KES {product.price}</p>
+    <div className="border rounded p-2 space-y-2">
+      <Link href={`/products/${product._id}`}> 
+        <img src={product.imageUrl} alt={product.name} className="w-full h-40 object-cover" />
+        <h3 className="font-semibold mt-2">{product.name}</h3>
+        <p className="text-sm text-gray-500">{product.description}</p>
+        <p className="font-bold">KES {product.price}</p>
+      </Link>
+      <button className="bg-green-500 text-white px-2 py-1 w-full" onClick={() => addItem(product)}>
+        Add to Cart
+      </button>
     </div>
   );
 }

--- a/lib/cart.tsx
+++ b/lib/cart.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { Product } from '../types';
+
+interface CartContextValue {
+  items: Product[];
+  addItem: (p: Product) => void;
+  removeItem: (id?: string) => void;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('useCart must be used within CartProvider');
+  return ctx;
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<Product[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('cart');
+    if (stored) setItems(JSON.parse(stored));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(items));
+  }, [items]);
+
+  const addItem = (p: Product) => setItems((prev) => [...prev, p]);
+  const removeItem = (id?: string) => {
+    if (!id) return;
+    setItems((prev) => prev.filter((i) => i._id !== id));
+  };
+  const clear = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, clear }}>
+      {children}
+    </CartContext.Provider>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,16 +3,19 @@ import '../styles/globals.css';
 import WhatsAppButton from '../components/WhatsAppButton';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import { CartProvider } from '../lib/cart';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <main className="flex-grow">
-        <Component {...pageProps} />
-      </main>
-      <Footer />
-      <WhatsAppButton />
-    </div>
+    <CartProvider>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-grow">
+          <Component {...pageProps} />
+        </main>
+        <Footer />
+        <WhatsAppButton />
+      </div>
+    </CartProvider>
   );
 }

--- a/pages/api/products/[id].ts
+++ b/pages/api/products/[id].ts
@@ -4,7 +4,12 @@ import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await connect();
-  if (req.method === 'DELETE') {
+  if (req.method === 'GET') {
+    const product = await (Product as any)
+      .findById(req.query.id as string)
+      .lean();
+    res.json(product);
+  } else if (req.method === 'DELETE') {
     await (Product as any).findByIdAndDelete(req.query.id as string);
     res.json({});
   } else {

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { Product, Order } from '../types';
+import { useCart } from '../lib/cart';
 
 export default function Checkout() {
+  const { items, clear, removeItem } = useCart();
   const [form, setForm] = useState<Omit<Order, '_id' | 'createdAt'>>({
     customerName: '',
     phone: '',
@@ -14,16 +16,32 @@ export default function Checkout() {
   };
 
   const submit = async () => {
+    const order: Omit<Order, '_id' | 'createdAt'> = {
+      ...form,
+      items
+    };
     await fetch('/api/orders', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form)
+      body: JSON.stringify(order)
     });
+    clear();
     alert('Order received! We will contact you shortly.');
   };
 
   return (
     <div className="p-4 space-y-2">
+      <h2 className="text-lg font-semibold">Cart Items</h2>
+      {items.length === 0 && <p>Your cart is empty.</p>}
+      {items.map((item) => (
+        <div key={item._id} className="flex justify-between border-b py-1">
+          <span>{item.name}</span>
+          <button className="text-red-600" onClick={() => removeItem(item._id)}>
+            remove
+          </button>
+        </div>
+      ))}
+
       <input className="border p-1 w-full" name="customerName" placeholder="Name" onChange={handleChange} />
       <input className="border p-1 w-full" name="phone" placeholder="Phone" onChange={handleChange} />
       <input className="border p-1 w-full" name="address" placeholder="Address" onChange={handleChange} />

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,0 +1,57 @@
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import ProductCard from '../../components/ProductCard';
+import { Product } from '../../types';
+import { useCart } from '../../lib/cart';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function ProductPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { addItem } = useCart();
+
+  const { data: product, error } = useSWR<Product>(
+    id ? `/api/products/${id}` : null,
+    fetcher
+  );
+  const { data: products } = useSWR<Product[]>('/api/products', fetcher);
+
+  if (error) return <div>Failed to load</div>;
+  if (!product) return <div>Loading...</div>;
+
+  const others = products?.filter(p => p._id !== id) || [];
+
+  const checkoutNow = () => {
+    addItem(product);
+    router.push('/checkout');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="border p-4 space-y-2">
+        <img src={product.imageUrl} alt={product.name} className="w-full h-60 object-cover" />
+        <h2 className="text-xl font-bold">{product.name}</h2>
+        <p>{product.description}</p>
+        <p className="font-bold">KES {product.price}</p>
+        <div className="space-x-2">
+          <button className="bg-green-500 text-white px-3 py-1" onClick={() => addItem(product)}>
+            Add to Cart
+          </button>
+          <button className="bg-blue-600 text-white px-3 py-1" onClick={checkoutNow}>
+            Checkout
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-2">Other Products</h3>
+        <div className="grid grid-cols-2 gap-4">
+          {others.map(p => (
+            <ProductCard key={p._id} product={p} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CartContext to manage cart state
- show cart size in header and provide Add to Cart buttons
- show products individually with related products
- display cart contents during checkout and include them in submitted order
- API endpoint now allows fetching a single product

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e5c2dd6fc83238d636a8e476a3056