### PR TITLE
Improve store landing and checkout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,18 @@
 export default function Footer() {
   return (
     <footer className="bg-gray-800 text-white text-sm text-center py-4 mt-10">
-      &copy; {new Date().getFullYear()} Mtumba Online
+      <div>&copy; {new Date().getFullYear()} Mtumba Online</div>
+      <div className="mt-2 space-x-4">
+        <a href="#" className="hover:underline">
+          Facebook
+        </a>
+        <a href="#" className="hover:underline">
+          Twitter
+        </a>
+        <a href="#" className="hover:underline">
+          Instagram
+        </a>
+      </div>
     </footer>
   );
 }

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -17,6 +17,7 @@ const OrderSchema = new mongoose.Schema({
   phone: String,
   address: String,
   items: Array,
+  paymentOption: String,
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -10,6 +10,8 @@ export default function Checkout() {
     address: '',
     items: []
   });
+  const [paymentOption, setPaymentOption] = useState<'ondelivery' | 'paynow'>('ondelivery');
+  const [paymentLink, setPaymentLink] = useState<string | null>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -18,15 +20,18 @@ export default function Checkout() {
   const submit = async () => {
     const order: Omit<Order, '_id' | 'createdAt'> = {
       ...form,
-      items
+      items,
+      paymentOption
     };
-    await fetch('/api/orders', {
+    const res = await fetch('/api/orders', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(order)
     });
+    const saved = await res.json();
     clear();
-    alert('Order received! We will contact you shortly.');
+    setPaymentLink(`https://pay.example.com/${saved._id}`);
+    alert('Order received! Use the link below to pay when ready.');
   };
 
   return (
@@ -45,8 +50,38 @@ export default function Checkout() {
       <input className="border p-1 w-full" name="customerName" placeholder="Name" onChange={handleChange} />
       <input className="border p-1 w-full" name="phone" placeholder="Phone" onChange={handleChange} />
       <input className="border p-1 w-full" name="address" placeholder="Address" onChange={handleChange} />
+      <div className="space-x-4">
+        <label>
+          <input
+            type="radio"
+            value="ondelivery"
+            name="payment"
+            checked={paymentOption === 'ondelivery'}
+            onChange={() => setPaymentOption('ondelivery')}
+          />{' '}
+          Pay on Delivery
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="paynow"
+            name="payment"
+            checked={paymentOption === 'paynow'}
+            onChange={() => setPaymentOption('paynow')}
+          />{' '}
+          Pay Now
+        </label>
+      </div>
       <p>M-Pesa instructions will be sent to your phone.</p>
       <button className="bg-green-500 text-white px-3 py-1" onClick={submit}>Submit</button>
+      {paymentLink && (
+        <p className="mt-2">
+          Payment link: {' '}
+          <a href={paymentLink} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+            {paymentLink}
+          </a>
+        </p>
+      )}
     </div>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,10 +11,30 @@ export default function Home() {
   if (!data) return <div>Loading...</div>;
 
   return (
-    <div className="grid grid-cols-2 gap-4 p-4">
-      {data.map(p => (
-        <ProductCard key={p._id} product={p} />
-      ))}
+    <div>
+      <section className="relative h-64 flex items-center justify-center text-white mb-4">
+        <img
+          src="https://source.unsplash.com/random/900x600?clothes"
+          alt="Store"
+          className="absolute inset-0 w-full h-full object-cover opacity-70"
+        />
+        <div className="relative text-center space-y-2">
+          <h1 className="text-2xl font-bold">Quality Second-hand Clothing</h1>
+          <p>Affordable styles for everyone</p>
+          <a
+            href="#products"
+            className="inline-block bg-green-600 px-4 py-2 rounded text-white"
+          >
+            See Products
+          </a>
+        </div>
+      </section>
+
+      <div id="products" className="grid grid-cols-2 gap-4 p-4">
+        {data.map(p => (
+          <ProductCard key={p._id} product={p} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/types.ts
+++ b/types.ts
@@ -16,5 +16,6 @@ export interface Order {
   phone: string;
   address: string;
   items: Product[];
+  paymentOption?: 'ondelivery' | 'paynow';
   createdAt?: string;
 }


### PR DESCRIPTION
## Summary
- add placeholder social links in footer
- add hero section with call-to-action on home page
- allow pay-now vs pay-on-delivery in checkout and show payment link
- store payment option in order schema

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e7b7469cc83238d88ab50ea190e72