### PR TITLE
Improve loading UX with spinner

### DIFF
--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Spinner() {
+  return (
+    <div className="flex justify-center items-center p-4" role="status">
+      <div className="w-8 h-8 border-4 border-blue-500 border-solid rounded-full animate-spin border-t-transparent" />
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import useSWR from 'swr';
 import ProductCard from '../components/ProductCard';
+import Spinner from '../components/Spinner';
 import { Product } from '../types';
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
@@ -7,12 +8,8 @@ const fetcher = (url: string) => fetch(url).then(res => res.json());
 export default function Home() {
   const { data, error } = useSWR<Product[]>('/api/products', fetcher);
 
-  if (error) return <div>Failed to load</div>;
-  if (!data) return <div>Loading...</div>;
-
-  return (
-    <div>
-      <section className="relative h-64 flex items-center justify-center text-white mb-4">
+  const hero = (
+    <section className="relative h-64 flex items-center justify-center text-white mb-4">
         <img
           src="https://source.unsplash.com/random/900x600?clothes"
           alt="Store"
@@ -29,12 +26,28 @@ export default function Home() {
           </a>
         </div>
       </section>
+  );
 
-      <div id="products" className="grid grid-cols-2 gap-4 p-4">
-        {data.map(p => (
-          <ProductCard key={p._id} product={p} />
-        ))}
+  if (error)
+    return (
+      <div>
+        {hero}
+        <div className="text-center text-red-600">Failed to load</div>
       </div>
+    );
+
+  return (
+    <div>
+      {hero}
+      {!data ? (
+        <Spinner />
+      ) : (
+        <div id="products" className="grid grid-cols-2 gap-4 p-4">
+          {data.map(p => (
+            <ProductCard key={p._id} product={p} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import ProductCard from '../../components/ProductCard';
+import Spinner from '../../components/Spinner';
 import { Product } from '../../types';
 import { useCart } from '../../lib/cart';
 
@@ -18,7 +19,7 @@ export default function ProductPage() {
   const { data: products } = useSWR<Product[]>('/api/products', fetcher);
 
   if (error) return <div>Failed to load</div>;
-  if (!product) return <div>Loading...</div>;
+  if (!product) return <Spinner />;
 
   const others = products?.filter(p => p._id !== id) || [];
 


### PR DESCRIPTION
## Summary
- add a reusable `Spinner` component
- display the hero section immediately and show a spinner while products load
- replace product page loading text with the spinner

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685eaeb501808323b957db4607f983f9