### PR TITLE
Add iconography

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,16 +1,18 @@
+import { FaFacebook, FaTwitter, FaInstagram } from 'react-icons/fa';
+
 export default function Footer() {
   return (
     <footer className="bg-gray-800 text-white text-sm text-center py-4 mt-10">
       <div>&copy; {new Date().getFullYear()} Mtumba Online</div>
-      <div className="mt-2 space-x-4">
-        <a href="#" className="hover:underline">
-          Facebook
+      <div className="mt-2 space-x-4 flex justify-center">
+        <a href="#" className="hover:underline inline-flex items-center gap-1">
+          <FaFacebook /> Facebook
         </a>
-        <a href="#" className="hover:underline">
-          Twitter
+        <a href="#" className="hover:underline inline-flex items-center gap-1">
+          <FaTwitter /> Twitter
         </a>
-        <a href="#" className="hover:underline">
-          Instagram
+        <a href="#" className="hover:underline inline-flex items-center gap-1">
+          <FaInstagram /> Instagram
         </a>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { HomeIcon, ShoppingCartIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { useCart } from '../lib/cart';
 
 export default function Header() {
@@ -9,15 +10,15 @@ export default function Header() {
         <Link href="/" className="text-2xl font-bold hover:opacity-90">
           Mtumba Online
         </Link>
-        <nav className="space-x-6">
-          <Link href="/" className="hover:underline">
-            Home
+        <nav className="space-x-6 flex items-center">
+          <Link href="/" className="hover:underline inline-flex items-center gap-1">
+            <HomeIcon className="w-5 h-5" /> Home
           </Link>
-          <Link href="/checkout" className="hover:underline">
-            Cart ({items.length})
+          <Link href="/checkout" className="hover:underline inline-flex items-center gap-1">
+            <ShoppingCartIcon className="w-5 h-5" /> Cart ({items.length})
           </Link>
-          <Link href="/admin" className="hover:underline">
-            Admin
+          <Link href="/admin" className="hover:underline inline-flex items-center gap-1">
+            <Cog6ToothIcon className="w-5 h-5" /> Admin
           </Link>
         </nav>
       </div>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { ShoppingCartIcon } from '@heroicons/react/24/outline';
 import { Product } from '../types';
 import { useCart } from '../lib/cart';
 
@@ -22,10 +23,10 @@ export default function ProductCard({ product }: Props) {
         <p className="font-bold">KES {product.price}</p>
       </Link>
       <button
-        className="bg-green-500 hover:bg-green-600 text-white w-full py-2 font-semibold"
+        className="bg-green-500 hover:bg-green-600 text-white w-full py-2 font-semibold flex items-center justify-center gap-1"
         onClick={() => addItem(product)}
       >
-        Add to Cart
+        <ShoppingCartIcon className="w-5 h-5" /> Add to Cart
       </button>
     </div>
   );

--- a/components/WhatsAppButton.tsx
+++ b/components/WhatsAppButton.tsx
@@ -1,3 +1,5 @@
+import { FaWhatsapp } from 'react-icons/fa';
+
 export default function WhatsAppButton() {
   return (
     <a
@@ -6,7 +8,7 @@ export default function WhatsAppButton() {
       rel="noopener noreferrer"
       className="fixed bottom-4 right-4 bg-green-500 hover:bg-green-600 text-white p-4 rounded-full shadow-lg flex items-center justify-center transition"
     >
-      💬
+      <FaWhatsapp className="w-6 h-6" />
     </a>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "mongoose": "^8.15.2",
         "next": "^15.3.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "swr": "^2.3.3"
       },
       "devDependencies": {
@@ -45,6 +47,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -2056,6 +2067,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "mongoose": "^8.15.2",
     "next": "^15.3.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "swr": "^2.3.3"
   },
   "devDependencies": {

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { TrashIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
 import { Product } from '../../types';
 
 export default function Admin() {
@@ -53,7 +54,9 @@ export default function Admin() {
           <input className="border rounded p-2 w-full" name="category" placeholder="Category" onChange={handleChange} />
           <input className="border rounded p-2 w-full" name="color" placeholder="Color" onChange={handleChange} />
         </div>
-        <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={submit}>Add Product</button>
+        <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded inline-flex items-center gap-1" onClick={submit}>
+          <PlusCircleIcon className="w-5 h-5" /> Add Product
+        </button>
       </div>
 
       <table className="min-w-full text-sm border divide-y divide-gray-200">
@@ -68,7 +71,9 @@ export default function Admin() {
             <tr key={p._id} className="border-t">
               <td className="px-4 py-2">{p.name}</td>
               <td className="px-4 py-2 text-right">
-                <button className="text-red-600 hover:underline" onClick={() => del(p._id)}>Delete</button>
+                <button className="text-red-600 hover:underline inline-flex items-center gap-1" onClick={() => del(p._id)}>
+                  <TrashIcon className="w-5 h-5" /> Delete
+                </button>
               </td>
             </tr>
           ))}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { TrashIcon, ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import { Product, Order } from '../types';
 import { useCart } from '../lib/cart';
 
@@ -39,10 +40,10 @@ export default function Checkout() {
       <h2 className="text-lg font-semibold">Cart Items</h2>
       {items.length === 0 && <p>Your cart is empty.</p>}
       {items.map((item) => (
-        <div key={item._id} className="flex justify-between border-b py-1">
+        <div key={item._id} className="flex justify-between items-center border-b py-1">
           <span>{item.name}</span>
-          <button className="text-red-600" onClick={() => removeItem(item._id)}>
-            remove
+          <button className="text-red-600 inline-flex items-center" onClick={() => removeItem(item._id)}>
+            <TrashIcon className="w-5 h-5" />
           </button>
         </div>
       ))}
@@ -73,7 +74,9 @@ export default function Checkout() {
         </label>
       </div>
       <p>M-Pesa instructions will be sent to your phone.</p>
-      <button className="bg-green-500 text-white px-3 py-1" onClick={submit}>Submit</button>
+      <button className="bg-green-500 text-white px-3 py-1 inline-flex items-center gap-1" onClick={submit}>
+        Submit <ArrowRightCircleIcon className="w-5 h-5" />
+      </button>
       {paymentLink && (
         <p className="mt-2">
           Payment link: {' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import ProductCard from '../components/ProductCard';
 import Spinner from '../components/Spinner';
+import { ArrowDownCircleIcon } from '@heroicons/react/24/outline';
 import { Product } from '../types';
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
@@ -20,9 +21,9 @@ export default function Home() {
           <p>Affordable styles for everyone</p>
           <a
             href="#products"
-            className="inline-block bg-green-600 px-4 py-2 rounded text-white"
+            className="inline-flex items-center gap-1 bg-green-600 px-4 py-2 rounded text-white"
           >
-            See Products
+            See Products <ArrowDownCircleIcon className="w-5 h-5" />
           </a>
         </div>
       </section>

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import ProductCard from '../../components/ProductCard';
 import Spinner from '../../components/Spinner';
+import { ShoppingCartIcon, ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import { Product } from '../../types';
 import { useCart } from '../../lib/cart';
 
@@ -36,11 +37,11 @@ export default function ProductPage() {
         <p>{product.description}</p>
         <p className="font-bold">KES {product.price}</p>
         <div className="space-x-2">
-          <button className="bg-green-500 text-white px-3 py-1" onClick={() => addItem(product)}>
-            Add to Cart
+          <button className="bg-green-500 text-white px-3 py-1 inline-flex items-center gap-1" onClick={() => addItem(product)}>
+            <ShoppingCartIcon className="w-5 h-5" /> Add to Cart
           </button>
-          <button className="bg-blue-600 text-white px-3 py-1" onClick={checkoutNow}>
-            Checkout
+          <button className="bg-blue-600 text-white px-3 py-1 inline-flex items-center gap-1" onClick={checkoutNow}>
+            <ArrowRightCircleIcon className="w-5 h-5" /> Checkout
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use Heroicons and React Icons for visuals
- add icons to navigation links
- add icons for social links and WhatsApp chat
- add icons to product and cart actions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fb565b29883238b9cc6324758eab5