### PR TITLE
Add payment confirmation workflow

### DIFF
--- a/lib/models.ts
+++ b/lib/models.ts
@@ -21,5 +21,14 @@ const OrderSchema = new mongoose.Schema({
   createdAt: { type: Date, default: Date.now }
 });
 
+const ConfirmationSchema = new mongoose.Schema({
+  orderId: mongoose.Schema.Types.ObjectId,
+  phone: String,
+  message: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
 export const Product = mongoose.models.Product || mongoose.model('Product', ProductSchema);
 export const Order = mongoose.models.Order || mongoose.model('Order', OrderSchema);
+export const Confirmation =
+  mongoose.models.Confirmation || mongoose.model('Confirmation', ConfirmationSchema);

--- a/pages/admin/confirmations.tsx
+++ b/pages/admin/confirmations.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Confirmation } from '../../types';
+
+export default function ConfirmationsPage() {
+  const [confirmations, setConfirmations] = useState<Confirmation[]>([]);
+
+  useEffect(() => {
+    fetch('/api/confirmations').then(res => res.json()).then(setConfirmations);
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Payment Confirmations</h1>
+      <table className="min-w-full text-sm border divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-2 py-1 text-left">Order ID</th>
+            <th className="px-2 py-1 text-left">Phone</th>
+            <th className="px-2 py-1 text-left">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {confirmations.map(c => (
+            <tr key={c._id} className="border-t">
+              <td className="px-2 py-1">{c.orderId}</td>
+              <td className="px-2 py-1">{c.phone}</td>
+              <td className="px-2 py-1">{c.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { TrashIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
 import { Product } from '../../types';
 
@@ -42,6 +43,14 @@ export default function Admin() {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-6">
       <h1 className="text-2xl font-bold">Admin Panel</h1>
+      <div className="space-x-4">
+        <Link href="/admin/orders" className="underline text-blue-600">
+          View Orders
+        </Link>
+        <Link href="/admin/confirmations" className="underline text-blue-600">
+          View Confirmations
+        </Link>
+      </div>
 
       <div className="bg-white rounded shadow p-4 space-y-4">
         <div className="grid md:grid-cols-2 gap-4">

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Order } from '../../types';
+
+export default function OrdersPage() {
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    fetch('/api/orders').then(res => res.json()).then(setOrders);
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Orders</h1>
+      <table className="min-w-full text-sm border divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-2 py-1 text-left">Customer</th>
+            <th className="px-2 py-1 text-left">Phone</th>
+            <th className="px-2 py-1 text-left">Items</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map(o => (
+            <tr key={o._id} className="border-t">
+              <td className="px-2 py-1">{o.customerName}</td>
+              <td className="px-2 py-1">{o.phone}</td>
+              <td className="px-2 py-1">{o.items.length}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/api/confirmations/index.ts
+++ b/pages/api/confirmations/index.ts
@@ -1,15 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { Order } from '../../../lib/models';
+import { Confirmation } from '../../../lib/models';
 import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await connect();
   if (req.method === 'GET') {
-    const orders = await (Order as any).find().lean();
-    res.json(orders);
+    const confirmations = await (Confirmation as any).find().lean();
+    res.json(confirmations);
   } else if (req.method === 'POST') {
-    const order = await (Order as any).create(req.body);
-    res.json(order);
+    const confirmation = await (Confirmation as any).create(req.body);
+    res.json(confirmation);
   } else {
     res.status(405).end();
   }

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -31,7 +31,7 @@ export default function Checkout() {
     });
     const saved = await res.json();
     clear();
-    setPaymentLink(`https://pay.example.com/${saved._id}`);
+    setPaymentLink(`/pay/${saved._id}`);
     alert('Order received! Use the link below to pay when ready.');
   };
 
@@ -40,8 +40,9 @@ export default function Checkout() {
       <h2 className="text-lg font-semibold">Cart Items</h2>
       {items.length === 0 && <p>Your cart is empty.</p>}
       {items.map((item) => (
-        <div key={item._id} className="flex justify-between items-center border-b py-1">
-          <span>{item.name}</span>
+        <div key={item._id} className="flex items-center justify-between border-b py-1 gap-2">
+          <img src={item.imageUrl} alt={item.name} className="w-10 h-10 object-cover" />
+          <span className="flex-1">{item.name}</span>
           <button className="text-red-600 inline-flex items-center" onClick={() => removeItem(item._id)}>
             <TrashIcon className="w-5 h-5" />
           </button>
@@ -78,12 +79,22 @@ export default function Checkout() {
         Submit <ArrowRightCircleIcon className="w-5 h-5" />
       </button>
       {paymentLink && (
-        <p className="mt-2">
-          Payment link: {' '}
-          <a href={paymentLink} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
-            {paymentLink}
+        <div className="mt-2 space-x-2">
+          <a
+            href={paymentLink}
+            className="bg-blue-600 text-white px-3 py-1 rounded inline-block"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Go to Payment
           </a>
-        </p>
+          <button
+            className="bg-gray-200 px-3 py-1 rounded"
+            onClick={() => paymentLink && navigator.clipboard.writeText(paymentLink)}
+          >
+            Copy Link
+          </button>
+        </div>
       )}
     </div>
   );

--- a/pages/pay/[id].tsx
+++ b/pages/pay/[id].tsx
@@ -1,0 +1,46 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export default function PayPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [phone, setPhone] = useState('');
+  const [message, setMessage] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const submit = async () => {
+    if (!id) return;
+    await fetch('/api/confirmations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId: id, phone, message })
+    });
+    setSent(true);
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">Payment Confirmation</h1>
+      <input
+        className="border p-2 w-full"
+        placeholder="Phone number used"
+        value={phone}
+        onChange={e => setPhone(e.target.value)}
+      />
+      <textarea
+        className="border p-2 w-full"
+        rows={4}
+        placeholder="Paste M-Pesa confirmation message"
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+      />
+      <button
+        onClick={submit}
+        className="bg-green-600 text-white px-4 py-2 rounded"
+      >
+        Submit
+      </button>
+      {sent && <p className="text-green-600">Confirmation received.</p>}
+    </div>
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -12,10 +12,19 @@ export interface Product {
 }
 
 export interface Order {
+  _id?: string;
   customerName: string;
   phone: string;
   address: string;
   items: Product[];
   paymentOption?: 'ondelivery' | 'paynow';
+  createdAt?: string;
+}
+
+export interface Confirmation {
+  _id?: string;
+  orderId: string;
+  phone: string;
+  message: string;
   createdAt?: string;
 }


### PR DESCRIPTION
## Summary
- add `Confirmation` model and type
- show item preview images on the checkout page
- show payment link button with clipboard copy
- allow GET requests for orders API
- add confirmations API endpoint
- payment page for submitting confirmation
- admin links and pages to view orders and confirmations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ff4b185a08323ab9b7c42b29ff547