### PR TITLE
Add order detail page and confirmation status toggle

### DIFF
--- a/lib/models.ts
+++ b/lib/models.ts
@@ -25,6 +25,7 @@ const ConfirmationSchema = new mongoose.Schema({
   orderId: mongoose.Schema.Types.ObjectId,
   phone: String,
   message: String,
+  status: { type: String, enum: ['approved', 'pending'], default: 'pending' },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/pages/admin/confirmations.tsx
+++ b/pages/admin/confirmations.tsx
@@ -17,6 +17,7 @@ export default function ConfirmationsPage() {
             <th className="px-2 py-1 text-left">Order ID</th>
             <th className="px-2 py-1 text-left">Phone</th>
             <th className="px-2 py-1 text-left">Message</th>
+            <th className="px-2 py-1 text-left">Status</th>
           </tr>
         </thead>
         <tbody>
@@ -25,6 +26,7 @@ export default function ConfirmationsPage() {
               <td className="px-2 py-1">{c.orderId}</td>
               <td className="px-2 py-1">{c.phone}</td>
               <td className="px-2 py-1">{c.message}</td>
+              <td className="px-2 py-1">{c.status}</td>
             </tr>
           ))}
         </tbody>

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -22,7 +22,11 @@ export default function OrdersPage() {
         <tbody>
           {orders.map(o => (
             <tr key={o._id} className="border-t">
-              <td className="px-2 py-1">{o.customerName}</td>
+              <td className="px-2 py-1">
+                <a href={`/admin/orders/${o._id}`} className="text-blue-600 underline">
+                  {o.customerName}
+                </a>
+              </td>
               <td className="px-2 py-1">{o.phone}</td>
               <td className="px-2 py-1">{o.items.length}</td>
             </tr>

--- a/pages/admin/orders/[id].tsx
+++ b/pages/admin/orders/[id].tsx
@@ -1,0 +1,70 @@
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import { Order, Confirmation } from '../../../types';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function OrderDetailsPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data, mutate } = useSWR<{ order: Order; confirmation?: Confirmation }>(
+    id ? `/api/orders/${id}` : null,
+    fetcher
+  );
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  const { order, confirmation } = data;
+
+  const toggleStatus = async () => {
+    if (!confirmation) return;
+    const newStatus = confirmation.status === 'pending' ? 'approved' : 'pending';
+    await fetch(`/api/confirmations/${confirmation._id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: newStatus })
+    });
+    mutate();
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-2">
+      <h1 className="text-2xl font-bold mb-2">Order Details</h1>
+      <p>
+        <strong>Customer:</strong> {order.customerName}
+      </p>
+      <p>
+        <strong>Phone:</strong> {order.phone}
+      </p>
+      <p>
+        <strong>Address:</strong> {order.address}
+      </p>
+      <p>
+        <strong>Payment Option:</strong> {order.paymentOption}
+      </p>
+      <h2 className="text-xl font-semibold mt-4">Items</h2>
+      <ul className="list-disc ml-4">
+        {order.items.map((item, idx) => (
+          <li key={idx}>
+            {item.name} - KES {item.price}
+          </li>
+        ))}
+      </ul>
+      {confirmation ? (
+        <div className="mt-4 space-y-2">
+          <p>
+            <strong>Confirmation Status:</strong> {confirmation.status}
+          </p>
+          <button
+            className="bg-blue-600 text-white px-3 py-1 rounded"
+            onClick={toggleStatus}
+          >
+            Toggle Status
+          </button>
+        </div>
+      ) : (
+        <p className="mt-4">No payment confirmation.</p>
+      )}
+    </div>
+  );
+}

--- a/pages/api/confirmations/[id].ts
+++ b/pages/api/confirmations/[id].ts
@@ -4,15 +4,17 @@ import { connect } from '../../../lib/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await connect();
+  const { id } = req.query;
+
   if (req.method === 'GET') {
-    const confirmations = await (Confirmation as any).find().lean();
-    res.json(confirmations);
-  } else if (req.method === 'POST') {
-    const confirmation = await (Confirmation as any).create({
-      ...req.body,
-      status: 'pending'
-    });
+    const confirmation = await (Confirmation as any).findById(id).lean();
+    if (!confirmation) return res.status(404).end();
     res.json(confirmation);
+  } else if (req.method === 'PUT') {
+    const updated = await (Confirmation as any).findByIdAndUpdate(id, req.body, {
+      new: true
+    });
+    res.json(updated);
   } else {
     res.status(405).end();
   }

--- a/pages/api/orders/[id].ts
+++ b/pages/api/orders/[id].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Order, Confirmation } from '../../../lib/models';
+import { connect } from '../../../lib/db';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
+  const { id } = req.query;
+
+  if (req.method === 'GET') {
+    const order = await (Order as any).findById(id).lean();
+    if (!order) return res.status(404).end();
+    const confirmation = await (Confirmation as any)
+      .findOne({ orderId: id })
+      .lean();
+    res.json({ order, confirmation });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/pay/[id].tsx
+++ b/pages/pay/[id].tsx
@@ -13,7 +13,7 @@ export default function PayPage() {
     await fetch('/api/confirmations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderId: id, phone, message })
+      body: JSON.stringify({ orderId: id, phone, message, status: 'pending' })
     });
     setSent(true);
   };

--- a/types.ts
+++ b/types.ts
@@ -26,5 +26,6 @@ export interface Confirmation {
   orderId: string;
   phone: string;
   message: string;
+  status?: 'approved' | 'pending';
   createdAt?: string;
 }


### PR DESCRIPTION
## Summary
- add `status` field to confirmations schema and type
- return confirmation details when querying a single order
- allow creating confirmations with default status pending
- expose APIs to fetch and update individual confirmations and orders
- add admin order details page with status toggle
- link order list to order details and show confirmation status column

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ffbf6c3cc83239c30d7e2ac658d9e