### PR TITLE
Add Mpesa admin entry and auto matching cron

### DIFF
--- a/lib/cron.ts
+++ b/lib/cron.ts
@@ -1,0 +1,23 @@
+import cron from 'node-cron';
+import { connect } from './db';
+import { Confirmation } from './models';
+
+export function startCron() {
+  cron.schedule('*/5 * * * *', async () => {
+    await connect();
+    const mpesaMessages = await (Confirmation as any).find({ source: 'mpesa' }).lean();
+    for (const msg of mpesaMessages) {
+      const pendingUser = await (Confirmation as any).findOne({
+        source: 'user',
+        message: msg.message,
+        status: 'pending'
+      });
+      if (pendingUser) {
+        pendingUser.status = 'approved';
+        await pendingUser.save();
+      }
+    }
+  });
+}
+
+startCron();

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -25,6 +25,7 @@ const ConfirmationSchema = new mongoose.Schema({
   orderId: mongoose.Schema.Types.ObjectId,
   phone: String,
   message: String,
+  source: { type: String, enum: ['user', 'mpesa'], default: 'user' },
   status: { type: String, enum: ['approved', 'pending'], default: 'pending' },
   createdAt: { type: Date, default: Date.now }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@heroicons/react": "^2.2.0",
         "mongoose": "^8.15.2",
         "next": "^15.3.3",
+        "node-cron": "^4.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -1775,6 +1776,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.1.tgz",
+      "integrity": "sha512-oJj9CYV7teeCVs+y2Efi5IQ4FGmAYbsXQOehc1AGLlwteec8pC7DjBCUzSyRQ0LYa+CRCgmD+vtlWQcnPpXowA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "swr": "^2.3.3"
+    "swr": "^2.3.3",
+    "node-cron": "^4.1.1"
   },
   "devDependencies": {
     "@types/node": "24.0.3",

--- a/pages/admin/confirmations.tsx
+++ b/pages/admin/confirmations.tsx
@@ -17,6 +17,7 @@ export default function ConfirmationsPage() {
             <th className="px-2 py-1 text-left">Order ID</th>
             <th className="px-2 py-1 text-left">Phone</th>
             <th className="px-2 py-1 text-left">Message</th>
+            <th className="px-2 py-1 text-left">Source</th>
             <th className="px-2 py-1 text-left">Status</th>
           </tr>
         </thead>
@@ -26,6 +27,7 @@ export default function ConfirmationsPage() {
               <td className="px-2 py-1">{c.orderId}</td>
               <td className="px-2 py-1">{c.phone}</td>
               <td className="px-2 py-1">{c.message}</td>
+              <td className="px-2 py-1">{c.source}</td>
               <td className="px-2 py-1">{c.status}</td>
             </tr>
           ))}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -50,6 +50,9 @@ export default function Admin() {
         <Link href="/admin/confirmations" className="underline text-blue-600">
           View Confirmations
         </Link>
+        <Link href="/admin/utils/submit-mpesa" className="underline text-blue-600">
+          Add M-Pesa Message
+        </Link>
       </div>
 
       <div className="bg-white rounded shadow p-4 space-y-4">

--- a/pages/admin/utils/submit-mpesa.tsx
+++ b/pages/admin/utils/submit-mpesa.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+export default function SubmitMpesa() {
+  const [message, setMessage] = useState('');
+  const [phone, setPhone] = useState('');
+  const [orderId, setOrderId] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const submit = async () => {
+    await fetch('/api/mpesa', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId, phone, message })
+    });
+    setSent(true);
+    setMessage('');
+    setPhone('');
+    setOrderId('');
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-2">
+      <h1 className="text-xl font-bold">Record M-Pesa Message</h1>
+      <input
+        className="border p-2 w-full"
+        placeholder="Order ID (optional)"
+        value={orderId}
+        onChange={e => setOrderId(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Sender Phone"
+        value={phone}
+        onChange={e => setPhone(e.target.value)}
+      />
+      <textarea
+        className="border p-2 w-full"
+        rows={4}
+        placeholder="Full M-Pesa message"
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+      />
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={submit}
+      >
+        Save Message
+      </button>
+      {sent && <p className="text-green-600">Message saved.</p>}
+    </div>
+  );
+}

--- a/pages/api/confirmations/index.ts
+++ b/pages/api/confirmations/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Confirmation } from '../../../lib/models';
 import { connect } from '../../../lib/db';
+import '../../../lib/cron';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await connect();
@@ -10,6 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   } else if (req.method === 'POST') {
     const confirmation = await (Confirmation as any).create({
       ...req.body,
+      source: req.body.source || 'user',
       status: 'pending'
     });
     res.json(confirmation);

--- a/pages/api/mpesa.ts
+++ b/pages/api/mpesa.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Confirmation } from '../../lib/models';
+import { connect } from '../../lib/db';
+import '../../lib/cron';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
+  if (req.method === 'POST') {
+    const { orderId, phone, message } = req.body;
+    const confirmation = await (Confirmation as any).create({
+      orderId,
+      phone,
+      message,
+      source: 'mpesa',
+      status: 'pending'
+    });
+    res.json(confirmation);
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/pay/[id].tsx
+++ b/pages/pay/[id].tsx
@@ -13,7 +13,13 @@ export default function PayPage() {
     await fetch('/api/confirmations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderId: id, phone, message, status: 'pending' })
+      body: JSON.stringify({
+        orderId: id,
+        phone,
+        message,
+        status: 'pending',
+        source: 'user'
+      })
     });
     setSent(true);
   };

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,7 @@ export interface Confirmation {
   orderId: string;
   phone: string;
   message: string;
+  source?: 'user' | 'mpesa';
   status?: 'approved' | 'pending';
   createdAt?: string;
 }


### PR DESCRIPTION
## Summary
- allow specifying message source in confirmations model
- add admin page to manually record Mpesa messages
- expose `/api/mpesa` for automated message posting
- periodically approve user confirmations that match Mpesa messages
- wire cron scheduler into API

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68601e73269083239a064c5941778f12