### PR TITLE
Add admin authentication

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,26 @@
+import jwt from 'jsonwebtoken';
+import { AdminUser } from './models';
+import { connect } from './db';
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+export function signToken(id: string) {
+  return jwt.sign({ id }, SECRET, { expiresIn: '3d' });
+}
+
+export async function verifyAdmin(req: { headers: { cookie?: string } }) {
+  const cookieHeader = req.headers.cookie || '';
+  const token = cookieHeader
+    .split(';')
+    .map(c => c.trim())
+    .find(c => c.startsWith('admin-token='))?.split('=')[1];
+  if (!token) return null;
+  try {
+    const decoded = jwt.verify(token, SECRET) as any;
+    await connect();
+    const admin = await (AdminUser as any).findById(decoded.id).lean();
+    return admin;
+  } catch {
+    return null;
+  }
+}

--- a/lib/initAdmin.ts
+++ b/lib/initAdmin.ts
@@ -1,0 +1,10 @@
+import { AdminUser } from './models';
+import bcrypt from 'bcryptjs';
+
+export async function ensureDefaultAdmin() {
+  const existing = await (AdminUser as any).findOne({ username: 'qaid' });
+  if (!existing) {
+    const hash = await bcrypt.hash('jond', 10);
+    await (AdminUser as any).create({ username: 'qaid', passwordHash: hash });
+  }
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -35,3 +35,11 @@ export const Product = mongoose.models.Product || mongoose.model('Product', Prod
 export const Order = mongoose.models.Order || mongoose.model('Order', OrderSchema);
 export const Confirmation =
   mongoose.models.Confirmation || mongoose.model('Confirmation', ConfirmationSchema);
+
+const AdminUserSchema = new mongoose.Schema({
+  username: { type: String, unique: true },
+  passwordHash: String,
+});
+
+export const AdminUser =
+  mongoose.models.AdminUser || mongoose.model('AdminUser', AdminUserSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "bcryptjs": "^3.0.2",
+        "cookie": "^1.0.2",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.15.2",
         "next": "^15.3.3",
         "node-cron": "^4.1.1",
@@ -885,6 +888,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
@@ -971,6 +983,12 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1137,6 +1155,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1251,6 +1278,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.167",
@@ -1708,6 +1744,49 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -1735,6 +1814,48 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -2457,6 +2578,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -2468,7 +2609,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -14,14 +14,17 @@
   "type": "commonjs",
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "bcryptjs": "^3.0.2",
+    "cookie": "^1.0.2",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.2",
     "next": "^15.3.3",
+    "node-cron": "^4.1.1",
+    "node-mailjet": "^6.0.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "swr": "^2.3.3",
-    "node-cron": "^4.1.1",
-    "node-mailjet": "^6.0.8"
+    "swr": "^2.3.3"
   },
   "devDependencies": {
     "@types/node": "24.0.3",

--- a/pages/admin/confirmations.tsx
+++ b/pages/admin/confirmations.tsx
@@ -5,7 +5,15 @@ export default function ConfirmationsPage() {
   const [confirmations, setConfirmations] = useState<Confirmation[]>([]);
 
   useEffect(() => {
-    fetch('/api/confirmations').then(res => res.json()).then(setConfirmations);
+    fetch('/api/admin/me').then(res => {
+      if (res.status === 401) {
+        window.location.href = '/admin/login';
+      } else {
+        fetch('/api/confirmations')
+          .then(r => r.json())
+          .then(setConfirmations);
+      }
+    });
   }, []);
 
   return (

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -17,7 +17,13 @@ export default function Admin() {
   });
 
   useEffect(() => {
-    fetch('/api/products').then(res => res.json()).then(setProducts);
+    fetch('/api/admin/me').then(res => {
+      if (res.status === 401) {
+        window.location.href = '/admin/login';
+      } else {
+        fetch('/api/products').then(r => r.json()).then(setProducts);
+      }
+    });
   }, []);
 
   const submit = async () => {
@@ -52,6 +58,9 @@ export default function Admin() {
         </Link>
         <Link href="/admin/utils/submit-mpesa" className="underline text-blue-600">
           Add M-Pesa Message
+        </Link>
+        <Link href="/admin/users" className="underline text-blue-600">
+          Manage Users
         </Link>
       </div>
 

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function AdminLogin() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async () => {
+    const res = await fetch('/api/admin/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      router.push('/admin');
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto p-4 space-y-2">
+      <h1 className="text-xl font-bold">Admin Login</h1>
+      <input
+        className="border p-2 w-full"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={submit}>
+        Login
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -5,7 +5,13 @@ export default function OrdersPage() {
   const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
-    fetch('/api/orders').then(res => res.json()).then(setOrders);
+    fetch('/api/admin/me').then(res => {
+      if (res.status === 401) {
+        window.location.href = '/admin/login';
+      } else {
+        fetch('/api/orders').then(r => r.json()).then(setOrders);
+      }
+    });
   }, []);
 
   return (

--- a/pages/admin/orders/[id].tsx
+++ b/pages/admin/orders/[id].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
+import { useEffect } from 'react';
 import { Order, Confirmation } from '../../../types';
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
@@ -7,6 +8,13 @@ const fetcher = (url: string) => fetch(url).then(res => res.json());
 export default function OrderDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
+  useEffect(() => {
+    fetch('/api/admin/me').then(res => {
+      if (res.status === 401) {
+        window.location.href = '/admin/login';
+      }
+    });
+  }, []);
   const { data, mutate } = useSWR<{ order: Order; confirmation?: Confirmation }>(
     id ? `/api/orders/${id}` : null,
     fetcher

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+interface User { username: string }
+
+export default function ManageUsers() {
+  const router = useRouter();
+  const [users, setUsers] = useState<User[]>([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const load = async () => {
+    const res = await fetch('/api/admin/users');
+    if (res.status === 401) {
+      router.push('/admin/login');
+      return;
+    }
+    const data = await res.json();
+    setUsers(data);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const addUser = async () => {
+    await fetch('/api/admin/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    setUsername('');
+    setPassword('');
+    load();
+  };
+
+  const removeUser = async (name: string) => {
+    await fetch('/api/admin/users', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: name }),
+    });
+    load();
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h1 className="text-xl font-bold">Manage Admin Users</h1>
+      <div className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={addUser}>
+          Add User
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {users.map(u => (
+          <li key={u.username} className="flex justify-between border p-2">
+            {u.username}
+            <button className="text-red-600" onClick={() => removeUser(u.username)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/admin/utils/submit-mpesa.tsx
+++ b/pages/admin/utils/submit-mpesa.tsx
@@ -1,10 +1,18 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function SubmitMpesa() {
   const [message, setMessage] = useState('');
   const [phone, setPhone] = useState('');
   const [orderId, setOrderId] = useState('');
   const [sent, setSent] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/admin/me').then(res => {
+      if (res.status === 401) {
+        window.location.href = '/admin/login';
+      }
+    });
+  }, []);
 
   const submit = async () => {
     await fetch('/api/mpesa', {

--- a/pages/api/admin/login.ts
+++ b/pages/api/admin/login.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { connect } from '../../../lib/db';
+import { AdminUser } from '../../../lib/models';
+import { ensureDefaultAdmin } from '../../../lib/initAdmin';
+import bcrypt from 'bcryptjs';
+import { signToken } from '../../../lib/auth';
+import { serialize } from 'cookie';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  await connect();
+  await ensureDefaultAdmin();
+  const { username, password } = req.body;
+  const user = await (AdminUser as any).findOne({ username });
+  if (!user) return res.status(401).end('Invalid credentials');
+  const ok = await bcrypt.compare(password, user.passwordHash);
+  if (!ok) return res.status(401).end('Invalid credentials');
+  const token = signToken(user._id.toString());
+  res.setHeader(
+    'Set-Cookie',
+    serialize('admin-token', token, {
+      path: '/',
+      httpOnly: true,
+      maxAge: 60 * 60 * 24 * 3,
+    })
+  );
+  res.json({ ok: true });
+}

--- a/pages/api/admin/logout.ts
+++ b/pages/api/admin/logout.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { serialize } from 'cookie';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader(
+    'Set-Cookie',
+    serialize('admin-token', '', { path: '/', httpOnly: true, maxAge: 0 })
+  );
+  res.json({ ok: true });
+}

--- a/pages/api/admin/me.ts
+++ b/pages/api/admin/me.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyAdmin } from '../../../lib/auth';
+import { AdminUser } from '../../../lib/models';
+import { connect } from '../../../lib/db';
+import { ensureDefaultAdmin } from '../../../lib/initAdmin';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
+  await ensureDefaultAdmin();
+  const admin = await verifyAdmin(req);
+  if (!admin) return res.status(401).end();
+  res.json({ username: admin.username });
+}

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { connect } from '../../../lib/db';
+import { AdminUser } from '../../../lib/models';
+import { verifyAdmin } from '../../../lib/auth';
+import { ensureDefaultAdmin } from '../../../lib/initAdmin';
+import bcrypt from 'bcryptjs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await connect();
+  await ensureDefaultAdmin();
+  const admin = await verifyAdmin(req);
+  if (!admin) return res.status(401).end();
+
+  if (req.method === 'GET') {
+    const users = await (AdminUser as any).find().select('username').lean();
+    res.json(users);
+  } else if (req.method === 'POST') {
+    const { username, password } = req.body;
+    const hash = await bcrypt.hash(password, 10);
+    const user = await (AdminUser as any).create({ username, passwordHash: hash });
+    res.json({ username: user.username });
+  } else if (req.method === 'DELETE') {
+    const { username } = req.body;
+    await (AdminUser as any).deleteOne({ username });
+    res.json({ ok: true });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -31,3 +31,9 @@ export interface Confirmation {
   status?: 'approved' | 'pending';
   createdAt?: string;
 }
+
+export interface AdminUser {
+  _id?: string;
+  username: string;
+  passwordHash?: string;
+}


### PR DESCRIPTION
## Summary
- introduce `AdminUser` model and default admin setup
- create auth utilities and API routes for login/logout/user management
- add admin login page and user management UI
- protect admin pages with login checks
- include new dependencies for auth

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863bce506288323a37bf5b8756b0243