### PR TITLE
Add customer accounts and order workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a minimal Next.js + MongoDB eCommerce demo for a Kenyan second-hand clothing store.
 
+## New Features
+
+- Customers can sign up and log in to view their orders.
+- Orders now have a workflow status (pending, processed, shipped, delivered, cancelled) editable in the admin panel.
+
 ## Development
 
 ```bash

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -28,6 +28,12 @@ export default function Header() {
             <ShoppingCartIcon className="w-5 h-5" /> Cart ({items.length})
           </Link>
           <Link
+            href="/account/orders"
+            className="hover:underline inline-flex items-center gap-1"
+          >
+            Account
+          </Link>
+          <Link
             href="/admin"
             className="hover:underline inline-flex items-center gap-1"
           >

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,5 @@
 import jwt from "jsonwebtoken";
-import { AdminUser } from "./models";
+import { AdminUser, Customer } from "./models";
 import { connect } from "./db";
 
 const SECRET = process.env.JWT_SECRET || "secret";
@@ -21,6 +21,24 @@ export async function verifyAdmin(req: { headers: { cookie?: string } }) {
     await connect();
     const admin = await (AdminUser as any).findById(decoded.id).lean();
     return admin;
+  } catch {
+    return null;
+  }
+}
+
+export async function verifyUser(req: { headers: { cookie?: string } }) {
+  const cookieHeader = req.headers.cookie || "";
+  const token = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith("user-token="))
+    ?.split("=")[1];
+  if (!token) return null;
+  try {
+    const decoded = jwt.verify(token, SECRET) as any;
+    await connect();
+    const user = await (Customer as any).findById(decoded.id).lean();
+    return user;
   } catch {
     return null;
   }

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -19,6 +19,12 @@ const OrderSchema = new mongoose.Schema({
   address: String,
   items: Array,
   paymentOption: String,
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "Customer" },
+  status: {
+    type: String,
+    enum: ["pending", "processed", "shipped", "delivered", "cancelled"],
+    default: "pending",
+  },
   createdAt: { type: Date, default: Date.now },
 });
 
@@ -46,3 +52,12 @@ const AdminUserSchema = new mongoose.Schema({
 
 export const AdminUser =
   mongoose.models.AdminUser || mongoose.model("AdminUser", AdminUserSchema);
+
+const CustomerSchema = new mongoose.Schema({
+  email: { type: String, unique: true },
+  passwordHash: String,
+  name: String,
+});
+
+export const Customer =
+  mongoose.models.Customer || mongoose.model("Customer", CustomerSchema);

--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -1,0 +1,50 @@
+import useSWR from "swr";
+import { useEffect } from "react";
+import { Order } from "../../types";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function MyOrders() {
+  const { data: orders, error } = useSWR<Order[]>(
+    "/api/orders?mine=1",
+    fetcher,
+  );
+
+  useEffect(() => {
+    fetch("/api/users/me").then((res) => {
+      if (res.status === 401) {
+        window.location.href = "/login";
+      }
+    });
+  }, []);
+
+  if (error) return <div>Failed to load</div>;
+  if (!orders) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">My Orders</h1>
+      {orders.length === 0 && <p>No orders yet.</p>}
+      <table className="min-w-full text-sm border divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-2 py-1 text-left">Date</th>
+            <th className="px-2 py-1 text-left">Status</th>
+            <th className="px-2 py-1 text-left">Items</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((o) => (
+            <tr key={o._id} className="border-t">
+              <td className="px-2 py-1">
+                {new Date(o.createdAt || "").toLocaleDateString()}
+              </td>
+              <td className="px-2 py-1">{o.status}</td>
+              <td className="px-2 py-1">{o.items.length}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/admin/orders/[id].tsx
+++ b/pages/admin/orders/[id].tsx
@@ -36,6 +36,15 @@ export default function OrderDetailsPage() {
     mutate();
   };
 
+  const updateOrderStatus = async (status: string) => {
+    await fetch(`/api/orders/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    mutate();
+  };
+
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-2">
       <h1 className="text-2xl font-bold mb-2">Order Details</h1>
@@ -53,6 +62,22 @@ export default function OrderDetailsPage() {
       </p>
       <p>
         <strong>Payment Option:</strong> {order.paymentOption}
+      </p>
+      <p>
+        <strong>Order Status:</strong>{" "}
+        <select
+          value={order.status}
+          onChange={(e) => updateOrderStatus(e.target.value)}
+          className="border p-1 rounded"
+        >
+          {["pending", "processed", "shipped", "delivered", "cancelled"].map(
+            (s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ),
+          )}
+        </select>
       </p>
       <h2 className="text-xl font-semibold mt-4">Items</h2>
       <ul className="list-disc ml-4">

--- a/pages/api/orders/[id].ts
+++ b/pages/api/orders/[id].ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Order, Confirmation } from "../../../lib/models";
 import { connect } from "../../../lib/db";
+import { verifyAdmin } from "../../../lib/auth";
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,6 +17,14 @@ export default async function handler(
       .findOne({ orderId: id })
       .lean();
     res.json({ order, confirmation });
+  } else if (req.method === "PUT") {
+    const admin = await verifyAdmin(req);
+    if (!admin) return res.status(401).end();
+    const { status } = req.body;
+    const order = await (Order as any)
+      .findByIdAndUpdate(id, { status }, { new: true })
+      .lean();
+    res.json(order);
   } else {
     res.status(405).end();
   }

--- a/pages/api/orders/index.ts
+++ b/pages/api/orders/index.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { Order } from "../../../lib/models";
 import { connect } from "../../../lib/db";
 import { sendOrderEmail } from "../../../lib/email";
+import { verifyUser } from "../../../lib/auth";
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,10 +10,20 @@ export default async function handler(
 ) {
   await connect();
   if (req.method === "GET") {
-    const orders = await (Order as any).find().lean();
-    res.json(orders);
+    if (req.query.mine) {
+      const user = await verifyUser(req);
+      if (!user) return res.status(401).end();
+      const orders = await (Order as any).find({ userId: user._id }).lean();
+      res.json(orders);
+    } else {
+      const orders = await (Order as any).find().lean();
+      res.json(orders);
+    }
   } else if (req.method === "POST") {
-    const order = await (Order as any).create(req.body);
+    const user = await verifyUser(req);
+    const payload = { ...req.body };
+    if (user) payload.userId = user._id;
+    const order = await (Order as any).create(payload);
     try {
       await sendOrderEmail(order);
     } catch (e) {

--- a/pages/api/users/login.ts
+++ b/pages/api/users/login.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { connect } from "../../../lib/db";
+import { Customer } from "../../../lib/models";
+import bcrypt from "bcryptjs";
+import { signToken } from "../../../lib/auth";
+import { serialize } from "cookie";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") return res.status(405).end();
+  await connect();
+  const { email, password } = req.body;
+  const user = await (Customer as any).findOne({ email });
+  if (!user) return res.status(401).end("Invalid credentials");
+  const ok = await bcrypt.compare(password, user.passwordHash);
+  if (!ok) return res.status(401).end("Invalid credentials");
+  const token = signToken(user._id.toString());
+  res.setHeader(
+    "Set-Cookie",
+    serialize("user-token", token, {
+      path: "/",
+      httpOnly: true,
+      maxAge: 60 * 60 * 24 * 3,
+    }),
+  );
+  res.json({ email: user.email, name: user.name });
+}

--- a/pages/api/users/logout.ts
+++ b/pages/api/users/logout.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { serialize } from "cookie";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader(
+    "Set-Cookie",
+    serialize("user-token", "", { path: "/", httpOnly: true, maxAge: 0 }),
+  );
+  res.json({ ok: true });
+}

--- a/pages/api/users/me.ts
+++ b/pages/api/users/me.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { verifyUser } from "../../../lib/auth";
+import { connect } from "../../../lib/db";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  await connect();
+  const user = await verifyUser(req);
+  if (!user) return res.status(401).end();
+  res.json({ email: user.email, name: user.name, _id: user._id });
+}

--- a/pages/api/users/signup.ts
+++ b/pages/api/users/signup.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { connect } from "../../../lib/db";
+import { Customer } from "../../../lib/models";
+import bcrypt from "bcryptjs";
+import { signToken } from "../../../lib/auth";
+import { serialize } from "cookie";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") return res.status(405).end();
+  await connect();
+  const { email, name, password } = req.body;
+  const existing = await (Customer as any).findOne({ email });
+  if (existing) return res.status(400).end("User exists");
+  const hash = await bcrypt.hash(password, 10);
+  const user = await (Customer as any).create({
+    email,
+    name,
+    passwordHash: hash,
+  });
+  const token = signToken(user._id.toString());
+  res.setHeader(
+    "Set-Cookie",
+    serialize("user-token", token, {
+      path: "/",
+      httpOnly: true,
+      maxAge: 60 * 60 * 24 * 3,
+    }),
+  );
+  res.json({ email: user.email, name: user.name });
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    const res = await fetch("/api/users/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      router.push("/account/orders");
+    } else {
+      setError("Invalid credentials");
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto p-6 space-y-4 bg-white rounded shadow">
+      <h1 className="text-xl font-bold">Login</h1>
+      <input
+        className="border rounded p-2 w-full"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="border rounded p-2 w-full"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button
+        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+        onClick={submit}
+      >
+        Login
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+
+export default function Signup() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    const res = await fetch("/api/users/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, name, password }),
+    });
+    if (res.ok) {
+      router.push("/account/orders");
+    } else {
+      const text = await res.text();
+      setError(text);
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto p-6 space-y-4 bg-white rounded shadow">
+      <h1 className="text-xl font-bold">Sign Up</h1>
+      <input
+        className="border rounded p-2 w-full"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="border rounded p-2 w-full"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className="border rounded p-2 w-full"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button
+        className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+        onClick={submit}
+      >
+        Sign Up
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -19,6 +19,8 @@ export interface Order {
   address: string;
   items: Product[];
   paymentOption?: "ondelivery" | "paynow";
+  status?: "pending" | "processed" | "shipped" | "delivered" | "cancelled";
+  userId?: string;
   createdAt?: string;
 }
 
@@ -35,5 +37,12 @@ export interface Confirmation {
 export interface AdminUser {
   _id?: string;
   username: string;
+  passwordHash?: string;
+}
+
+export interface Customer {
+  _id?: string;
+  email: string;
+  name: string;
   passwordHash?: string;
 }


### PR DESCRIPTION
## Summary
- introduce `Customer` model and `userId`/`status` fields on orders
- add signup, login and logout API endpoints and pages
- allow fetching orders for the current user
- support updating order status in admin
- show account link in the header

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863e74502988323a0abb6216036dc95