### PR TITLE
Improve MongoDB URI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ npm install
 npm run dev
 ```
 
-Set `MONGODB_URI` in `.env` to connect to MongoDB. To enable email notifications,
-also provide `MAILJET_API_KEY`, `MAILJET_SECRET_KEY` and `MAILJET_FROM`.
+Set `MONGODB_URI` in `.env` to connect to MongoDB. If not provided, the app
+defaults to `mongodb://127.0.0.1:27017/ecommerce`. To enable email
+notifications, also provide `MAILJET_API_KEY`, `MAILJET_SECRET_KEY` and
+`MAILJET_FROM`.
 
 ## Production
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,8 +1,9 @@
 import mongoose from "mongoose";
 
+// Connection string for MongoDB. An environment variable can override the
+// default local database used in development.
 const MONGODB_URI =
-  process.env.MONGODB_URI ||
-  "mongodb+srv://kaziwavijana:GvQCkSIcufEY1mgH@cluster0.1kkzax7.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0";
+  process.env.MONGODB_URI || "mongodb://127.0.0.1:27017/ecommerce";
 
 // Use a global cached connection across hot reloads in development.
 let cached = (global as any).mongoose as


### PR DESCRIPTION
## Summary
- look for `MONGODB_URI` environment variable in MongoDB helper
- default to a local database if the variable is missing
- document the environment variable

## Testing
- `npm run format`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864b22722a883238b1fcb437effc0be