### PR TITLE
Use spinner for loading states

### DIFF
--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 import { useEffect } from "react";
 import { Order } from "../../types";
+import Spinner from "../../components/Spinner";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -19,7 +20,7 @@ export default function MyOrders() {
   }, []);
 
   if (error) return <div>Failed to load</div>;
-  if (!orders) return <div>Loading...</div>;
+  if (!orders) return <Spinner />;
 
   return (
     <div className="max-w-3xl mx-auto p-4">

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Spinner from "../../components/Spinner";
 
 export default function AdminLogin() {
   const router = useRouter();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const submit = async () => {
+    setLoading(true);
     const res = await fetch("/api/admin/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -18,6 +21,7 @@ export default function AdminLogin() {
     } else {
       setError("Invalid credentials");
     }
+    setLoading(false);
   };
 
   return (
@@ -36,8 +40,12 @@ export default function AdminLogin() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <button className="btn-primary" onClick={submit}>
-        Login
+      <button
+        className="btn-primary flex justify-center"
+        onClick={submit}
+        disabled={loading}
+      >
+        {loading ? <Spinner /> : "Login"}
       </button>
       {error && <p className="text-red-600">{error}</p>}
     </div>

--- a/pages/admin/orders/[id].tsx
+++ b/pages/admin/orders/[id].tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import useSWR from "swr";
 import { useEffect } from "react";
 import { Order, Confirmation } from "../../../types";
+import Spinner from "../../../components/Spinner";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -20,7 +21,12 @@ export default function OrderDetailsPage() {
     confirmation?: Confirmation;
   }>(id ? `/api/orders/${id}` : null, fetcher);
 
-  if (!data) return <div className="p-4">Loading...</div>;
+  if (!data)
+    return (
+      <div className="p-4">
+        <Spinner />
+      </div>
+    );
 
   const { order, confirmation } = data;
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import Spinner from "../components/Spinner";
 
 export default function Login() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const submit = async () => {
+    setLoading(true);
     const res = await fetch("/api/users/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -18,6 +21,7 @@ export default function Login() {
     } else {
       setError("Invalid credentials");
     }
+    setLoading(false);
   };
 
   return (
@@ -36,8 +40,12 @@ export default function Login() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <button className="btn-primary" onClick={submit}>
-        Login
+      <button
+        className="btn-primary flex justify-center"
+        onClick={submit}
+        disabled={loading}
+      >
+        {loading ? <Spinner /> : "Login"}
       </button>
       {error && <p className="text-red-600">{error}</p>}
       <p className="text-sm">


### PR DESCRIPTION
## Summary
- show spinner during login actions
- replace text "Loading..." with spinner in account and admin order pages

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ba25593608323869ff5e3d0cbf338