### PR TITLE
Add account icon to header navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import {
   HomeIcon,
   ShoppingCartIcon,
   Cog6ToothIcon,
+  UserCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useCart } from "../lib/cart";
 
@@ -31,7 +32,7 @@ export default function Header() {
             href="/account/orders"
             className="hover:underline inline-flex items-center gap-1"
           >
-            Account
+            <UserCircleIcon className="w-5 h-5" /> Account
           </Link>
           <Link
             href="/admin"


### PR DESCRIPTION
## Summary
- display a user account icon next to the account link in the header

## Testing
- `npx prettier --write components/Header.tsx`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d10aa35a08323b191d7e8fa3d35d5