### PR TITLE
Enable admin creation

### DIFF
--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -10,6 +10,8 @@ export default function ManageUsers() {
   const [users, setUsers] = useState<User[]>([]);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
 
   const load = async () => {
     const res = await fetch("/api/admin/users");
@@ -26,14 +28,22 @@ export default function ManageUsers() {
   }, []);
 
   const addUser = async () => {
-    await fetch("/api/admin/users", {
+    setError("");
+    setSuccess("");
+    const res = await fetch("/api/admin/users", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),
     });
-    setUsername("");
-    setPassword("");
-    load();
+    if (res.ok) {
+      setSuccess("User added");
+      setUsername("");
+      setPassword("");
+      load();
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || "Failed to add user");
+    }
   };
 
   const removeUser = async (name: string) => {
@@ -65,6 +75,8 @@ export default function ManageUsers() {
         <button className="btn-primary" onClick={addUser}>
           Add User
         </button>
+        {success && <p className="text-green-600">{success}</p>}
+        {error && <p className="text-red-600">{error}</p>}
       </div>
       <ul className="space-y-1">
         {users.map((u) => (

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -20,11 +20,19 @@ export default async function handler(
   } else if (req.method === "POST") {
     const { username, password } = req.body;
     const hash = await bcrypt.hash(password, 10);
-    const user = await (AdminUser as any).create({
-      username,
-      passwordHash: hash,
-    });
-    res.json({ username: user.username });
+    try {
+      const user = await (AdminUser as any).create({
+        username,
+        passwordHash: hash,
+      });
+      res.json({ username: user.username });
+    } catch (err: any) {
+      if (err.code === 11000) {
+        return res.status(400).json({ error: "User already exists" });
+      }
+      console.error(err);
+      res.status(500).json({ error: "Failed to create user" });
+    }
   } else if (req.method === "DELETE") {
     const { username } = req.body;
     await (AdminUser as any).deleteOne({ username });


### PR DESCRIPTION
## Summary
- allow admins to be created via API with duplicate checks
- show success and error messages when adding admins

## Testing
- `npm run format`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fabe4f8bc8323adac8218de5a8ba4