### PR TITLE
Add WhatsApp order buttons

### DIFF
--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -38,6 +38,22 @@ export default function Checkout() {
     alert("Order received! Use the link below to pay when ready.");
   };
 
+  const orderOnWhatsApp = () => {
+    if (items.length === 0) return;
+    const base = window.location.origin;
+    const details = items
+      .map(
+        (i) =>
+          `${i.name}\nURL: ${base}/products/${i._id}\nPrice: KES ${i.price}`,
+      )
+      .join("\n\n");
+    const msg = `Hello, I want to purchase \n${details}`;
+    const url =
+      "https://api.whatsapp.com/send?phone=254700474550&text=" +
+      encodeURIComponent(msg);
+    window.open(url, "_blank");
+  };
+
   return (
     <div className="max-w-md mx-auto p-4 space-y-3">
       <h2 className="text-lg font-semibold">Cart Items</h2>
@@ -111,6 +127,9 @@ export default function Checkout() {
       <p>M-Pesa instructions will be sent to your phone.</p>
       <button className="btn-success" onClick={submit}>
         Submit <ArrowRightCircleIcon className="w-5 h-5" />
+      </button>
+      <button className="btn-primary" onClick={orderOnWhatsApp}>
+        Order on WhatsApp
       </button>
       {paymentLink && (
         <div className="mt-2 space-x-2">

--- a/pages/products/[id].tsx
+++ b/pages/products/[id].tsx
@@ -6,6 +6,7 @@ import {
   ShoppingCartIcon,
   ArrowRightCircleIcon,
 } from "@heroicons/react/24/outline";
+import { FaWhatsapp } from "react-icons/fa";
 import { Product } from "../../types";
 import { useCart } from "../../lib/cart";
 
@@ -32,6 +33,15 @@ export default function ProductPage() {
     router.push("/checkout");
   };
 
+  const orderOnWhatsApp = () => {
+    const base = window.location.origin;
+    const msg = `Hello, I want to purchase\n${product.name}\nURL: ${base}/products/${product._id}\nPrice: KES ${product.price}`;
+    const url =
+      "https://api.whatsapp.com/send?phone=254700474550&text=" +
+      encodeURIComponent(msg);
+    window.open(url, "_blank");
+  };
+
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-4">
       <div className="bg-white border rounded shadow p-4 space-y-3">
@@ -55,6 +65,12 @@ export default function ProductPage() {
             onClick={checkoutNow}
           >
             <ArrowRightCircleIcon className="w-5 h-5" /> Checkout
+          </button>
+          <button
+            className="bg-green-700 hover:bg-green-800 text-white px-4 py-2 rounded inline-flex items-center gap-1"
+            onClick={orderOnWhatsApp}
+          >
+            <FaWhatsapp className="w-5 h-5" /> Order on WhatsApp
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow ordering products via WhatsApp on the single product page
- allow ordering all cart items via WhatsApp on the checkout page

## Testing
- `npm run format`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68753b212010832382a1669a39854349