### PR TITLE
Add GCS bucket instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ MONGODB_URI=mongodb+srv://kaziwavijana:GvQCkSIcufEY1mgH@cluster0.1kkzax7.mongodb
 MAILJET_API_KEY=your-mailjet-key
 MAILJET_SECRET_KEY=your-mailjet-secret
 MAILJET_FROM=noreply@example.com
+GCS_BUCKET_NAME=my-form-uploads
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+# GCP_PROJECT_ID=your-project-id

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ npm install
 npm run dev
 ```
 
-Set `MONGODB_URI` in `.env` to connect to MongoDB. If not provided, the app
+Copy `.env.example` to `.env` and update the values for your environment. Set
+`MONGODB_URI` in `.env` to connect to MongoDB. If not provided, the app
 defaults to `mongodb://127.0.0.1:27017/ecommerce`. To enable email
 notifications, also provide `MAILJET_API_KEY`, `MAILJET_SECRET_KEY` and
 `MAILJET_FROM`.
@@ -24,7 +25,8 @@ notifications, also provide `MAILJET_API_KEY`, `MAILJET_SECRET_KEY` and
 To upload product images to Google Cloud Storage, set `GCS_BUCKET_NAME` and
 `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service account JSON file with
 permission to upload objects. The optional `GCP_PROJECT_ID` can also be
-specified if not included in the credentials file.
+specified if not included in the credentials file. An example bucket name is
+`my-form-uploads`, which is provided in `.env.example`.
 
 ## Production
 


### PR DESCRIPTION
## Summary
- update README with `.env.example` instructions and example bucket
- add Google Cloud Storage env vars to `.env.example`

## Testing
- `npm run format`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687605977ed88323b8c17fb9056ee645