### PR TITLE
Handle GCS credentials in Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,7 @@ MAILJET_API_KEY=your-mailjet-key
 MAILJET_SECRET_KEY=your-mailjet-secret
 MAILJET_FROM=noreply@example.com
 GCS_BUCKET_NAME=my-form-uploads
+# Path to the service account JSON file. On Vercel you can store the JSON
+# itself in this variable and it will be written to /tmp at runtime.
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
 # GCP_PROJECT_ID=your-project-id

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ notifications, also provide `MAILJET_API_KEY`, `MAILJET_SECRET_KEY` and
 `MAILJET_FROM`.
 
 To upload product images to Google Cloud Storage, set `GCS_BUCKET_NAME` and
-`GOOGLE_APPLICATION_CREDENTIALS` pointing to a service account JSON file with
-permission to upload objects. The optional `GCP_PROJECT_ID` can also be
-specified if not included in the credentials file. An example bucket name is
-`my-form-uploads`, which is provided in `.env.example`.
+`GOOGLE_APPLICATION_CREDENTIALS`. In a traditional environment this should be
+the path to a service account JSON file. On serverless platforms such as
+Vercel, you can instead store the JSON itself in the environment variable; the
+API route will write it to a temporary file at runtime. The optional
+`GCP_PROJECT_ID` can also be specified if not included in the credentials file.
+An example bucket name is `my-form-uploads`, which is provided in `.env.example`.
 
 ## Production
 

--- a/pages/api/upload-url.ts
+++ b/pages/api/upload-url.ts
@@ -1,8 +1,27 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Storage } from "@google-cloud/storage";
 import { verifyAdmin } from "../../lib/auth";
+import fs from "fs";
+import path from "path";
 
 const bucketName = process.env.GCS_BUCKET_NAME || "";
+
+// Vercel does not allow bundling arbitrary files, but the Google Cloud
+// client expects GOOGLE_APPLICATION_CREDENTIALS to be a file path. If the
+// environment variable contains JSON instead of a path, write it to a
+// temporary location and update the variable accordingly before creating the
+// Storage instance.
+const creds = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (creds && creds.trim().startsWith("{") && creds.includes("private_key")) {
+  const tmpPath = path.join("/tmp", "gcp-creds.json");
+  try {
+    fs.writeFileSync(tmpPath, creds);
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = tmpPath;
+  } catch (err) {
+    console.error("Failed to write GCP credentials file", err);
+  }
+}
+
 const storage = new Storage();
 
 export default async function handler(


### PR DESCRIPTION
## Summary
- detect if `GOOGLE_APPLICATION_CREDENTIALS` contains JSON
- write the JSON to `/tmp/gcp-creds.json` at runtime
- document this behaviour in README and `.env.example`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a33688c3883238853d67c9e30aea6