### PR TITLE
Fix signed URL content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ An example bucket name is `my-form-uploads`, which is provided in `.env.example`
 Direct browser uploads require CORS to be enabled on the Google Cloud Storage
 bucket. The `upload-url` API route automatically sets a permissive CORS policy
 each time it is called. Set `GCS_CORS_ORIGINS` to a comma‑separated list to
-restrict the allowed origins (defaults to `*`).
+restrict the allowed origins (defaults to `*`). When requesting an upload URL,
+pass the file's MIME type via a `contentType` query parameter so the generated
+signature matches the upload request.
 
 If you prefer to manage CORS yourself, run the following with the
 [`gsutil`](https://cloud.google.com/storage/docs/gsutil) CLI:

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -60,7 +60,9 @@ export default function Admin() {
     if (!file) return;
     setImageFile(file);
     const res = await fetch(
-      `/api/upload-url?fileName=${encodeURIComponent(file.name)}`,
+      `/api/upload-url?fileName=${encodeURIComponent(
+        file.name,
+      )}&contentType=${encodeURIComponent(file.type)}`,
     );
     if (res.ok) {
       const { uploadUrl, publicUrl } = await res.json();

--- a/pages/api/upload-url.ts
+++ b/pages/api/upload-url.ts
@@ -55,6 +55,7 @@ export default async function handler(
   if (!admin) return res.status(401).end();
 
   const fileName = req.query.fileName;
+  const contentTypeParam = req.query.contentType;
   if (!bucketName || typeof fileName !== "string") {
     return res.status(400).json({ error: "Missing bucket or fileName" });
   }
@@ -63,11 +64,16 @@ export default async function handler(
   await ensureBucketCors(bucket);
   const file = bucket.file(fileName);
 
+  const contentType =
+    typeof contentTypeParam === "string" && contentTypeParam.trim() !== ""
+      ? contentTypeParam
+      : "application/octet-stream";
+
   const [url] = await file.getSignedUrl({
     version: "v4",
     action: "write",
     expires: Date.now() + 10 * 60 * 1000,
-    contentType: "application/octet-stream",
+    contentType,
   });
 
   const publicUrl = `https://storage.googleapis.com/${bucketName}/${fileName}`;


### PR DESCRIPTION
## Summary
- accept `contentType` query parameter in `upload-url` API
- set MIME type when requesting upload URL in admin page
- document `contentType` in README

## Testing
- `npm run build`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687b957994cc832383c50d135dae3ea6