### PR TITLE
Add temporary time API route

### DIFF
--- a/pages/api/time.js
+++ b/pages/api/time.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  const now = new Date();
+  res.json({
+    isoTime: now.toISOString(),
+    unixTime: now.getTime(),
+    serverOffsetInMinutes: now.getTimezoneOffset(),
+  });
+}


### PR DESCRIPTION
## Summary
- add simple `time` API route that returns server time info

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687bb92693448323a47f1f1f58eacbc5